### PR TITLE
refactor(auth): login sin auto-creación de usuarios + TTL alineado a Firebase

### DIFF
--- a/.context/guidelines/router/authentication.md
+++ b/.context/guidelines/router/authentication.md
@@ -15,13 +15,14 @@
 
 | Dato            | Dónde guardar                                                                     | Notas                                                                                                         |
 | --------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `refreshToken`  | **Keychain** (iOS) / **Keystore + EncryptedSharedPreferences** (Android)          | Usar `react-native-keychain` o `expo-secure-store`. Persiste entre reinicios y cierres de app. Es el crítico. |
-| `accessToken`   | **Keychain** (iOS) / **Keystore** (Android) — misma lib                           | Persiste entre sesiones. Al abrir la app, si expiró (15 min), se dispara refresh automático.                  |
+| `refreshToken`  | **Keychain** (iOS) / **Android Keystore + SharedPreferences cifrado AES-GCM** (Android) | Usar **`expo-secure-store`** (módulo oficial Expo, ya instalado). Wrapper `secureStorage`. Persiste entre reinicios. Es el crítico. |
+| `accessToken`   | **Keychain** (iOS) / **Keystore** (Android) — misma lib (`expo-secure-store`)     | Persiste entre sesiones. Al abrir la app, si expiró (15 min), se dispara refresh automático.                  |
 | `user`          | **Zustand** (memoria) + puede cachearse en Keychain/Keystore para arranque rápido | Se rehidrata al iniciar la app desde almacenamiento seguro o desde `GET /auth/profile`.                       |
 | Preferencias UI | **AsyncStorage** — onboarding completado, tema, idioma, etc.                      | Datos no sensibles solamente.                                                                                 |
 
 **Reglas:**
 
+- **Lib por defecto: `expo-secure-store`.** No usar `react-native-keychain` salvo que se necesite biometría/Face ID gating o valores >2 KB (límite por valor de expo-secure-store). Esa decisión debe documentarse aparte.
 - **Prohibido** guardar tokens en `AsyncStorage`, `SharedPreferences` plain, `NSUserDefaults` o archivos sin cifrar.
 - **No sincronizar** el `refreshToken` a iCloud Keychain ni Google Backup. El refresh es per-device.
 - **Zustand** carga ambos tokens en memoria al iniciar la app (desde Keychain/Keystore). Durante la sesión activa se leen del store en memoria (rápido). Keychain/Keystore es la fuente de verdad persistente.
@@ -91,13 +92,13 @@
 
 **Errores:**
 
-| Código | Qué hacer                                                                                                                                                |
-| :----- | :------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `400`  | Body malformado. Bug del frontend — revisar payload.                                                                                                     |
-| `409`  | Email ya registrado. Mostrar error en el campo email.                                                                                                    |
+| Código | Qué hacer                                                                                                                                                                |
+| :----- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `400`  | Body malformado. Bug del frontend — revisar payload.                                                                                                                     |
+| `409`  | Email ya registrado. Mostrar error en el campo email.                                                                                                                    |
 | `422`  | Validación fallida (incluye contraseña rechazada por Firebase: débil/comprometida → `fields[].field = "password"`). Mapear `fields[]` a errores por campo en formulario. |
-| `429`  | Rate limit excedido (>3/min). Mostrar "Demasiados intentos, espera un momento" y deshabilitar el botón ~60s.                                             |
-| `500`  | Fallo interno al crear la cuenta (Firebase o DB). El backend revierte el registro parcial automáticamente. Mostrar error genérico y permitir reintentar. |
+| `429`  | Rate limit excedido (>3/min). Mostrar "Demasiados intentos, espera un momento" y deshabilitar el botón ~60s.                                                             |
+| `500`  | Fallo interno al crear la cuenta (Firebase o DB). El backend revierte el registro parcial automáticamente. Mostrar error genérico y permitir reintentar.                 |
 
 ---
 

--- a/.context/guidelines/router/authentication.md
+++ b/.context/guidelines/router/authentication.md
@@ -13,12 +13,12 @@
 
 > Kashy es mobile-only (React Native). No hay web.
 
-| Dato            | Dónde guardar                                                                     | Notas                                                                                                         |
-| --------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Dato            | Dónde guardar                                                                           | Notas                                                                                                                               |
+| --------------- | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | `refreshToken`  | **Keychain** (iOS) / **Android Keystore + SharedPreferences cifrado AES-GCM** (Android) | Usar **`expo-secure-store`** (módulo oficial Expo, ya instalado). Wrapper `secureStorage`. Persiste entre reinicios. Es el crítico. |
-| `accessToken`   | **Keychain** (iOS) / **Keystore** (Android) — misma lib (`expo-secure-store`)     | Persiste entre sesiones. Al abrir la app, si expiró (15 min), se dispara refresh automático.                  |
-| `user`          | **Zustand** (memoria) + puede cachearse en Keychain/Keystore para arranque rápido | Se rehidrata al iniciar la app desde almacenamiento seguro o desde `GET /auth/profile`.                       |
-| Preferencias UI | **AsyncStorage** — onboarding completado, tema, idioma, etc.                      | Datos no sensibles solamente.                                                                                 |
+| `accessToken`   | **Keychain** (iOS) / **Keystore** (Android) — misma lib (`expo-secure-store`)           | Persiste entre sesiones. Al abrir la app, si expiró (`expiresIn`, ~1h), se dispara refresh automático.                              |
+| `user`          | **Zustand** (memoria) + puede cachearse en Keychain/Keystore para arranque rápido       | Se rehidrata al iniciar la app desde almacenamiento seguro o desde `GET /auth/profile`.                                             |
+| Preferencias UI | **AsyncStorage** — onboarding completado, tema, idioma, etc.                            | Datos no sensibles solamente.                                                                                                       |
 
 **Reglas:**
 
@@ -27,6 +27,7 @@
 - **No sincronizar** el `refreshToken` a iCloud Keychain ni Google Backup. El refresh es per-device.
 - **Zustand** carga ambos tokens en memoria al iniciar la app (desde Keychain/Keystore). Durante la sesión activa se leen del store en memoria (rápido). Keychain/Keystore es la fuente de verdad persistente.
 - Al recibir tokens del backend, siempre **sobrescribir** en Keychain/Keystore antes de actualizar Zustand.
+- **TTL del `accessToken` (JWT custom):** el backend firma el JWT con el mismo `expiresIn` que devuelve el idToken de Firebase (~3600s / 1h), no un valor fijo. El cliente debe usar el `expiresIn` de la respuesta — nunca hardcodear 900/3600. Mantiene JWT custom y idToken de Firebase en la misma ventana.
 
 ---
 
@@ -119,9 +120,9 @@
 
 ```json
 {
-  "accessToken": "string (JWT custom, 15 min)",
+  "accessToken": "string (JWT custom, TTL = expiresIn del idToken de Firebase, ~3600s)",
   "refreshToken": "string (Firebase refresh, larga vida)",
-  "expiresIn": 900,
+  "expiresIn": 3600,
   "user": {
     "id": "uuid",
     "email": "string",
@@ -145,10 +146,12 @@
 
 **Errores:**
 
-| Código | Qué hacer                                                               |
-| :----- | :---------------------------------------------------------------------- |
-| `400`  | Body malformado. Bug del frontend — revisar payload.                    |
-| `401`  | Credenciales inválidas o email no verificado. Mostrar error al usuario. |
+| Código | Qué hacer                                                                                                                                                                              |
+| :----- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `400`  | Body malformado. Bug del frontend — revisar payload.                                                                                                                                   |
+| `401`  | Credenciales inválidas. Mostrar error al usuario.                                                                                                                                      |
+| `403`  | Email no verificado. Mostrar aviso de verificación + opción de reenviar correo.                                                                                                        |
+| `404`  | Auth Firebase OK pero el usuario no existe en la BD (cuenta huérfana). El login **no** crea usuarios — registro es la única vía de creación. Redirigir a registro o contactar soporte. |
 
 ---
 
@@ -170,9 +173,9 @@
 
 ```json
 {
-  "accessToken": "string (JWT custom, 15 min)",
+  "accessToken": "string (JWT custom, TTL = expiresIn del idToken de Firebase, ~3600s)",
   "refreshToken": "string (Firebase refresh, larga vida)",
-  "expiresIn": 900,
+  "expiresIn": 3600,
   "user": {
     "id": "uuid",
     "email": "string",
@@ -225,9 +228,9 @@
 
 ```json
 {
-  "accessToken": "string (nuevo JWT custom, 15 min)",
+  "accessToken": "string (nuevo JWT custom, TTL = expiresIn del idToken de Firebase, ~3600s)",
   "refreshToken": "string (rotado si Firebase entregó uno nuevo, sino el mismo)",
-  "expiresIn": 900
+  "expiresIn": 3600
 }
 ```
 

--- a/src/modules/auth/application/services/jwt-token.service.ts
+++ b/src/modules/auth/application/services/jwt-token.service.ts
@@ -19,7 +19,10 @@ export interface SignedJwt {
 export class JwtTokenService {
   constructor(private readonly jwtService: JwtService) {}
 
-  async signFor(user: User): Promise<SignedJwt> {
+  async signFor(
+    user: User,
+    ttlSeconds = JWT_DEFAULT_TTL_SECONDS,
+  ): Promise<SignedJwt> {
     const payload: JwtCustomPayload = {
       sub: user.id,
       email: user.email,
@@ -27,12 +30,12 @@ export class JwtTokenService {
     };
 
     const accessToken = await this.jwtService.signAsync(payload, {
-      expiresIn: JWT_DEFAULT_TTL_SECONDS,
+      expiresIn: ttlSeconds,
     });
 
     return {
       accessToken,
-      expiresIn: JWT_DEFAULT_TTL_SECONDS,
+      expiresIn: ttlSeconds,
     };
   }
 

--- a/src/modules/auth/application/use-cases/login-user.use-case.spec.ts
+++ b/src/modules/auth/application/use-cases/login-user.use-case.spec.ts
@@ -2,13 +2,12 @@ process.env.APP_ENCRYPTION_KEY ??=
   'a2tra2tra2tra2tra2tra2tra2tra2tra2tra2tra2s=';
 
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
-import type { EventEmitter2 } from '@nestjs/event-emitter';
 import type { IUserRepository } from '../../domain/interfaces/repositories/user.repository.interface';
 import type { IUserDeviceRepository } from '../../domain/interfaces/repositories/user-device.repository.interface';
 import type { IFirebaseAuthService } from '../../domain/interfaces/services/firebase-auth.service.interface';
-import { USER_REGISTERED } from '../../../../shared-kernel/domain/events/user.events';
 import { User } from '../../domain/entities/user.entity';
 import { EmailNotVerifiedException } from '../../domain/exceptions/email-not-verified.exception';
+import { UserNotFoundException } from '../../domain/exceptions/user-not-found.exception';
 import { JwtTokenService } from '../services/jwt-token.service';
 import { LoginUserUseCase } from './login-user.use-case';
 
@@ -17,7 +16,6 @@ describe('LoginUserUseCase', () => {
   let deviceRepository: jest.Mocked<IUserDeviceRepository>;
   let firebaseAuth: jest.Mocked<IFirebaseAuthService>;
   let jwtTokenService: jest.Mocked<JwtTokenService>;
-  let eventEmitter: jest.Mocked<EventEmitter2>;
   let useCase: LoginUserUseCase;
 
   const device = {
@@ -49,16 +47,12 @@ describe('LoginUserUseCase', () => {
     jwtTokenService = {
       signFor: jest.fn(),
     } as never;
-    eventEmitter = {
-      emitAsync: jest.fn().mockResolvedValue([] as never),
-    } as never;
 
     useCase = new LoginUserUseCase(
       userRepository,
       deviceRepository,
       firebaseAuth,
       jwtTokenService,
-      eventEmitter,
     );
 
     firebaseAuth.signIn.mockResolvedValue({
@@ -99,24 +93,21 @@ describe('LoginUserUseCase', () => {
     });
 
     expect(userRepository.save).not.toHaveBeenCalled();
-    expect(eventEmitter.emitAsync).not.toHaveBeenCalled();
     expect(deviceRepository.save).toHaveBeenCalled();
     expect(result.accessToken).toBe('jwt');
   });
 
-  it('crea user y emite USER_REGISTERED cuando firebaseUid no existe', async () => {
+  it('lanza UserNotFoundException cuando firebaseUid no existe en BD', async () => {
     userRepository.findByFirebaseUid.mockResolvedValue(null);
 
-    await useCase.execute({
-      dto: { email: 'jane@kashy.app', password: 'p' } as never,
-      device,
-    });
+    await expect(
+      useCase.execute({
+        dto: { email: 'jane@kashy.app', password: 'p' } as never,
+        device,
+      }),
+    ).rejects.toBeInstanceOf(UserNotFoundException);
 
-    expect(userRepository.save).toHaveBeenCalled();
-    expect(eventEmitter.emitAsync).toHaveBeenCalledWith(
-      USER_REGISTERED,
-      expect.objectContaining({ userId: expect.any(String) }),
-    );
+    expect(userRepository.save).not.toHaveBeenCalled();
   });
 
   it('respeta tiempo minimo de respuesta en happy path', async () => {

--- a/src/modules/auth/application/use-cases/login-user.use-case.ts
+++ b/src/modules/auth/application/use-cases/login-user.use-case.ts
@@ -1,5 +1,4 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { randomUUID } from 'crypto';
 import { UseCase } from '../../../../shared-kernel/application/use-case';
 import { withMinDuration } from '../../../../shared-kernel/utils/constant-time.util';
@@ -9,11 +8,6 @@ import type { IUserDeviceRepository } from '../../domain/interfaces/repositories
 import { USER_DEVICE_REPOSITORY } from '../../domain/interfaces/repositories/user-device.repository.interface';
 import type { IFirebaseAuthService } from '../../domain/interfaces/services/firebase-auth.service.interface';
 import { FIREBASE_AUTH_SERVICE } from '../../domain/interfaces/services/firebase-auth.service.interface';
-import {
-  USER_REGISTERED,
-  UserRegisteredEvent,
-} from '../../../../shared-kernel/domain/events/user.events';
-import { User } from '../../domain/entities/user.entity';
 import { UserDevice } from '../../domain/entities/user-device.entity';
 import { EmailNotVerifiedException } from '../../domain/exceptions/email-not-verified.exception';
 import { LoginUserDto } from '../dtos/login-user.dto';
@@ -21,6 +15,7 @@ import { AuthResponseDto } from '../dtos/auth-response.dto';
 import { UserMapper } from '../mappers/user.mapper';
 import { JwtTokenService } from '../services/jwt-token.service';
 import { DeviceInfo } from '../../infrastructure/decorators/device-info.decorator';
+import { UserNotFoundException } from '../../domain/exceptions/user-not-found.exception';
 
 interface LoginUserInput {
   dto: LoginUserDto;
@@ -42,7 +37,6 @@ export class LoginUserUseCase implements UseCase<
     @Inject(FIREBASE_AUTH_SERVICE)
     private readonly firebaseAuth: IFirebaseAuthService,
     private readonly jwtTokenService: JwtTokenService,
-    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   execute(input: LoginUserInput): Promise<AuthResponseDto> {
@@ -64,14 +58,19 @@ export class LoginUserUseCase implements UseCase<
       throw new EmailNotVerifiedException();
     }
 
-    const user = await this.findOrCreateUser(
+    const user = await this.userRepository.findByFirebaseUid(
       firebaseResult.firebaseUid,
-      firebaseResult.email,
     );
+    if (!user) {
+      throw new UserNotFoundException(dto.email);
+    }
 
     await this.upsertDevice(user.id, device);
 
-    const signed = await this.jwtTokenService.signFor(user);
+    const signed = await this.jwtTokenService.signFor(
+      user,
+      firebaseResult.expiresIn,
+    );
 
     return {
       accessToken: signed.accessToken,
@@ -79,27 +78,6 @@ export class LoginUserUseCase implements UseCase<
       expiresIn: signed.expiresIn,
       user: UserMapper.toResponse(user),
     };
-  }
-
-  private async findOrCreateUser(
-    firebaseUid: string,
-    email: string,
-  ): Promise<User> {
-    const existing = await this.userRepository.findByFirebaseUid(firebaseUid);
-    if (existing) return existing;
-
-    // Orphan recovery: Firebase tiene el usuario pero la BD no. country_code
-    // queda en 'VE' (mercado primario MVP); el usuario lo actualiza vía
-    // PATCH /auth/profile. Ver authentication.md.
-    const user = User.create(randomUUID(), firebaseUid, email, 'VE');
-    const saved = await this.userRepository.save(user);
-
-    await this.eventEmitter.emitAsync(
-      USER_REGISTERED,
-      new UserRegisteredEvent(saved.id),
-    );
-
-    return saved;
   }
 
   private async upsertDevice(
@@ -111,7 +89,7 @@ export class LoginUserUseCase implements UseCase<
     );
 
     if (existing && existing.userId === userId) {
-      const reassigned = existing.reassignToUser(
+      const reassigned = existing.refresh(
         userId,
         device.deviceName,
         device.platform,
@@ -135,6 +113,7 @@ export class LoginUserUseCase implements UseCase<
       device.appVersion,
       device.fcmToken,
     );
+
     await this.deviceRepository.save(newDevice);
   }
 }

--- a/src/modules/auth/application/use-cases/login-with-google.use-case.ts
+++ b/src/modules/auth/application/use-cases/login-with-google.use-case.ts
@@ -114,7 +114,7 @@ export class LoginWithGoogleUseCase implements UseCase<
     );
 
     if (existing && existing.userId === userId) {
-      const reassigned = existing.reassignToUser(
+      const reassigned = existing.refresh(
         userId,
         device.deviceName,
         device.platform,

--- a/src/modules/auth/application/use-cases/refresh-token.use-case.ts
+++ b/src/modules/auth/application/use-cases/refresh-token.use-case.ts
@@ -5,7 +5,10 @@ import type { IUserRepository } from '../../domain/interfaces/repositories/user.
 import { USER_REPOSITORY } from '../../domain/interfaces/repositories/user.repository.interface';
 import type { IUserDeviceRepository } from '../../domain/interfaces/repositories/user-device.repository.interface';
 import { USER_DEVICE_REPOSITORY } from '../../domain/interfaces/repositories/user-device.repository.interface';
-import type { IFirebaseAuthService } from '../../domain/interfaces/services/firebase-auth.service.interface';
+import type {
+  FirebaseRefreshResult,
+  IFirebaseAuthService,
+} from '../../domain/interfaces/services/firebase-auth.service.interface';
 import { FIREBASE_AUTH_SERVICE } from '../../domain/interfaces/services/firebase-auth.service.interface';
 import { RefreshResponseDto } from '../dtos/refresh-response.dto';
 import { JwtTokenService } from '../services/jwt-token.service';
@@ -35,7 +38,7 @@ export class RefreshTokenUseCase implements UseCase<
   async execute(input: RefreshTokenInput): Promise<RefreshResponseDto> {
     const { refreshToken, deviceId } = input;
 
-    let firebaseResult;
+    let firebaseResult: FirebaseRefreshResult;
     try {
       firebaseResult = await this.firebaseAuth.refreshIdToken(refreshToken);
     } catch (error) {
@@ -66,7 +69,10 @@ export class RefreshTokenUseCase implements UseCase<
     const touched = device.touch();
     await this.deviceRepository.save(touched);
 
-    const signed = await this.jwtTokenService.signFor(user);
+    const signed = await this.jwtTokenService.signFor(
+      user,
+      firebaseResult.expiresIn,
+    );
 
     return {
       accessToken: signed.accessToken,

--- a/src/modules/auth/domain/entities/user-device.entity.ts
+++ b/src/modules/auth/domain/entities/user-device.entity.ts
@@ -68,7 +68,7 @@ export class UserDevice extends BaseEntity {
     });
   }
 
-  reassignToUser(
+  refresh(
     userId: string,
     deviceName: string,
     platform: string,

--- a/src/modules/auth/infrastructure/controllers/auth.controller.ts
+++ b/src/modules/auth/infrastructure/controllers/auth.controller.ts
@@ -112,7 +112,7 @@ export class AuthController {
   @ApiOperation({
     summary: 'Login con email + password',
     description:
-      'Autentica contra Firebase, upserta el dispositivo en user_devices (sin almacenar refresh) y devuelve JWT custom (15 min) + refreshToken de Firebase + perfil. El cliente debe guardar el refreshToken en Keychain (iOS) o Keystore (Android).',
+      'Autentica contra Firebase, upserta el dispositivo en user_devices (sin almacenar refresh) y devuelve JWT custom (TTL = expiresIn del idToken de Firebase, ~3600s) + refreshToken de Firebase + perfil. El login no crea usuarios: registro es la unica via de creacion. El cliente debe guardar el refreshToken en Keychain (iOS) o Keystore (Android).',
   })
   @ApiHeader({ name: 'X-Device-Id', required: true })
   @ApiHeader({ name: 'X-Device-Name', required: true })
@@ -133,8 +133,24 @@ export class AuthController {
     type: AuthResponseDto,
   })
   @ApiResponse({
+    status: 400,
+    description: 'Body malformado',
+    type: ApiErrorResponse,
+  })
+  @ApiResponse({
     status: 401,
     description: 'Credenciales invalidas',
+    type: ApiErrorResponse,
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Email no verificado',
+    type: ApiErrorResponse,
+  })
+  @ApiResponse({
+    status: 404,
+    description:
+      'Auth Firebase OK pero el usuario no existe en la BD (cuenta huerfana). El login no crea usuarios.',
     type: ApiErrorResponse,
   })
   login(


### PR DESCRIPTION
## Cambios principales

### Login no crea usuarios
- `login-user.use-case`: elimina auto-create de cuentas huérfanas. Sin usuario para el UID de Firebase → `UserNotFoundException` (404). Registro = única vía de creación.

### TTL del JWT sigue a Firebase
- `jwt-token.service`: `signFor` acepta `ttlSeconds`. Login y refresh pasan `firebaseResult.expiresIn` → TTL del access token sigue al `idToken` de Firebase (~3600s) en vez de 900s fijo.
- `refresh-token.use-case`: `firebaseResult` tipado como `FirebaseRefreshResult`.

### Rename de dominio
- `UserDevice.reassignToUser` → `refresh`. Actualizado en login y login con Google.

### Docs + Swagger
- `authentication.md`: `expiresIn` = TTL de Firebase; errores separan 401 (credenciales) / 403 (email no verificado) / 404 (cuenta huérfana). Almacenamiento seguro por defecto: `expo-secure-store`.
- `auth.controller`: declara `@ApiResponse` 400/403/404 en `POST /auth/login`, corrige descripción del TTL.

### Tests
- `login-user.use-case.spec`: sincronizado con el refactor no-autocreate.