### PR TITLE
Fix/auth throttler recover password

### DIFF
--- a/.context/guidelines/flows/authentication.md
+++ b/.context/guidelines/flows/authentication.md
@@ -175,7 +175,7 @@ sequenceDiagram
     FE->>FE: Mostrar "Revisa tu correo" → Login
 ```
 
-No esperar `422` — el backend silencia errores de validación por seguridad.
+El backend silencia errores de negocio (email no existe → `204`, anti-enumeración), pero la validación de formato del email responde `422`.
 
 ---
 

--- a/.context/guidelines/router/authentication.md
+++ b/.context/guidelines/router/authentication.md
@@ -112,9 +112,11 @@
 ```json
 {
   "email": "string",
-  "password": "string"
+  "password": "string (sin validación de longitud)"
 }
 ```
+
+> El login **no** valida longitud de contraseña — `LoginUserDto` solo aplica `@IsString()`. La verificación real la hace Firebase contra el hash existente. Reglas `min 8 / max 64` solo aplican en `register`/`change-password`.
 
 **Esperar `200`:**
 

--- a/.context/guidelines/router/authentication.md
+++ b/.context/guidelines/router/authentication.md
@@ -274,11 +274,11 @@
 
 **Errores:**
 
-| Código | Qué hacer                                                 |
-| :----- | :-------------------------------------------------------- |
-| `400`  | Body no es JSON válido o falta `email`. Bug del frontend. |
+| Código | Qué hacer                                                                  |
+| :----- | :------------------------------------------------------------------------- |
+| `422`  | Email inválido o mal formado / `email` ausente. Validación fallida.        |
 
-> No esperar `422` — el backend silencia errores de validación de negocio en este endpoint por seguridad.
+> El backend silencia errores **de negocio** (email no existe → `204`, anti-enumeración), pero la validación de formato del email (`@IsEmail`) sí responde `422`.
 
 ---
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -64,6 +64,13 @@ import { NotificationsModule } from './modules/notifications/notifications.modul
 
     // Rate limiting
     ThrottlerModule.forRoot([
+      // Throttler base: lo sobrescriben los @Throttle({ default: ... }) por ruta.
+      // Sin este nombre 'default', esos overrides no aplican (silenciosamente).
+      {
+        name: 'default',
+        ttl: 60000,
+        limit: 100,
+      },
       {
         name: 'short',
         ttl: 1000,

--- a/src/modules/auth/application/dtos/login-user.dto.ts
+++ b/src/modules/auth/application/dtos/login-user.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsString, MinLength } from 'class-validator';
+import { IsEmail, IsString } from 'class-validator';
 
 export class LoginUserDto {
   @ApiProperty({ example: 'jane.doe@kashy.app' })
@@ -8,6 +8,5 @@ export class LoginUserDto {
 
   @ApiProperty({ example: 'StrongPass123' })
   @IsString()
-  @MinLength(8)
   password!: string;
 }

--- a/src/modules/auth/application/use-cases/recover-password.use-case.ts
+++ b/src/modules/auth/application/use-cases/recover-password.use-case.ts
@@ -31,7 +31,6 @@ export class RecoverPasswordUseCase implements UseCase<
       this.logger.warn(
         `Password reset email dispatch failed for ${dto.email}: ${message}`,
       );
-      // No re-lanzamos errores transitorios de Firebase para evitar leak por status code.
     }
   }
 }

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -28,9 +28,7 @@ import { AuthController } from './infrastructure/controllers/auth.controller';
 
 @Global()
 @Module({
-  imports: [
-    TypeOrmModule.forFeature([UserOrmEntity, UserDeviceOrmEntity]),
-  ],
+  imports: [TypeOrmModule.forFeature([UserOrmEntity, UserDeviceOrmEntity])],
   controllers: [AuthController],
   providers: [
     { provide: USER_REPOSITORY, useClass: TypeOrmUserRepository },
@@ -54,10 +52,6 @@ import { AuthController } from './infrastructure/controllers/auth.controller';
       useExisting: SyncFirebaseUserUseCase,
     },
   ],
-  exports: [
-    USER_READER,
-    USER_DEVICE_READER,
-    FIREBASE_USER_SYNC_PORT,
-  ],
+  exports: [USER_READER, USER_DEVICE_READER, FIREBASE_USER_SYNC_PORT],
 })
 export class AuthModule {}

--- a/src/modules/auth/infrastructure/controllers/auth.controller.ts
+++ b/src/modules/auth/infrastructure/controllers/auth.controller.ts
@@ -256,14 +256,14 @@ export class AuthController {
   })
   @ApiResponse({ status: 204, description: 'Email de recuperacion enviado' })
   @ApiResponse({
-    status: 400,
-    description: 'Email invalido',
-    type: ApiErrorResponse,
+    status: 422,
+    description: 'Email invalido o mal formado',
+    type: ApiValidationErrorResponse,
   })
   @ApiResponse({
-    status: 422,
-    description: 'Email mal formado',
-    type: ApiValidationErrorResponse,
+    status: 429,
+    description: 'Rate limit excedido (>3/min)',
+    type: ApiErrorResponse,
   })
   recoverPassword(@Body() dto: RecoverPasswordDto): Promise<void> {
     return this.recoverPasswordUseCase.execute(dto);


### PR DESCRIPTION
docs(auth): aclara login sin límite de longitud y corrige TTL del accessToken

- Marca password de login como libre (sin validación de longitud);
  reglas min 8/max 64 solo en register y change-password
- Corrige TTL del accessToken en doc frontend: 15 min/900 → ~3600s/1h
  para alinear con backend (TTL = expiresIn del idToken de Firebase)
