### PR TITLE
security(auth): bajar rate-limit de login/google a 3/min

### DIFF
--- a/src/modules/auth/application/use-cases/login-with-google.use-case.ts
+++ b/src/modules/auth/application/use-cases/login-with-google.use-case.ts
@@ -81,11 +81,11 @@ export class LoginWithGoogleUseCase implements UseCase<
     const existing = await this.userRepository.findByFirebaseUid(
       fb.firebaseUid,
     );
-    if (existing) return existing;
 
-    // Auto-registro Google: el body no trae country_code. Default 'VE'
-    // (mercado primario MVP); el usuario lo actualiza vía PATCH /auth/profile.
-    // Ver authentication.md.
+    if (existing) {
+      return existing;
+    }
+
     const user = User.create(
       randomUUID(),
       fb.firebaseUid,

--- a/src/modules/auth/infrastructure/controllers/auth.controller.ts
+++ b/src/modules/auth/infrastructure/controllers/auth.controller.ts
@@ -161,7 +161,7 @@ export class AuthController {
   }
 
   @Public()
-  @Throttle({ default: { limit: 5, ttl: 60_000 } })
+  @Throttle({ default: { limit: 3, ttl: 60_000 } })
   @Post('login/google')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
@@ -195,6 +195,11 @@ export class AuthController {
   @ApiResponse({
     status: 401,
     description: 'Token de Google rechazado',
+    type: ApiErrorResponse,
+  })
+  @ApiResponse({
+    status: 429,
+    description: 'Rate limit excedido (>3/min)',
     type: ApiErrorResponse,
   })
   loginGoogle(


### PR DESCRIPTION
Alinea el throttle de POST /auth/login/google con /auth/register (3 req/min). Como login/google hace auto-registro cuando el usuario no existe, mantener 5/min abria una via de creacion de cuentas mas laxa que el registro directo. Igualar el limite cierra esa brecha.